### PR TITLE
fix: Support newer tree-sitter versions and TypeScript grammar loading

### DIFF
--- a/symdex/core/parser.py
+++ b/symdex/core/parser.py
@@ -123,21 +123,26 @@ def _get_language(ext: str):
         mod = importlib.import_module(module_name)
         loader_candidates = []
         if preferred_loader:
+            loader_candidates.append(preferred_loader.upper())
             loader_candidates.append(preferred_loader)
         loader_candidates.extend(
             [
+                "LANGUAGE",
                 "language",
+                f"LANGUAGE_{lang_name.upper()}",
                 f"language_{lang_name}",
+                "LANGUAGE_TYPESCRIPT",
                 "language_typescript",
+                "LANGUAGE_PHP",
                 "language_php",
-                "language_php_only",
             ]
         )
         language = None
         for attr in dict.fromkeys(loader_candidates):
-            fn = getattr(mod, attr, None)
-            if callable(fn):
-                language = Language(fn())
+            val = getattr(mod, attr, None)
+            if val is not None:
+                language_ptr = val() if callable(val) else val
+                language = Language(language_ptr)
                 break
         if language is None:
             raise AttributeError(

--- a/symdex/graph/call_graph.py
+++ b/symdex/graph/call_graph.py
@@ -30,7 +30,29 @@ def _get_language(ext: str):
     try:
         from tree_sitter import Language, Parser as TSParser  # noqa: F401
         mod = importlib.import_module(module_name)
-        language = Language(mod.language())
+        
+        loader_candidates = [
+            "LANGUAGE",
+            "language",
+            f"LANGUAGE_{lang_name.upper()}",
+            f"language_{lang_name}",
+            "LANGUAGE_TYPESCRIPT",
+            "language_typescript",
+        ]
+        
+        language = None
+        for attr in dict.fromkeys(loader_candidates):
+            val = getattr(mod, attr, None)
+            if val is not None:
+                language_ptr = val() if callable(val) else val
+                language = Language(language_ptr)
+                break
+                
+        if language is None:
+            raise AttributeError(
+                f"No supported language loader found in module {module_name}"
+            )
+            
         return lang_name, language
     except Exception as exc:
         logger.warning("Could not load grammar for %s: %s", ext, exc)


### PR DESCRIPTION
**The Problem**
Parsing `.ts` or `.tsx` files currently crashes with `AttributeError: module 'tree_sitter_typescript' has no attribute 'language'`. This happens for two reasons:
1. `tree-sitter-typescript` exposes specific grammar names (e.g., `LANGUAGE_TYPESCRIPT`) rather than a generic language attribute.
2. `tree-sitter` versions >= 0.22.0 expose grammars as constant pointers (e.g., `LANGUAGE`) rather than callable functions.

**The Fix**
Updated the `_get_language` function in both `symdex/core/parser.py` and `symdex/graph/call_graph.py` to:
* Check a candidate list of attributes (including uppercase constants for `tree-sitter >= 0.22.0`).
* Explicitly check for TypeScript-specific exports (`LANGUAGE_TYPESCRIPT`, `language_typescript`).
* Gracefully handle both callable functions (older tree-sitter APIs) and constant properties (newer APIs).

Tested locally and successfully resolves the crash when indexing TypeScript files.