### PR TITLE
Added support to set the ip address when calling `symdex serve`

### DIFF
--- a/symdex/cli.py
+++ b/symdex/cli.py
@@ -839,18 +839,42 @@ def routes(
 @app.command()
 def serve(
     port: int = typer.Option(None, "--port", "-p", help="HTTP port (omit for stdio mode)"),
+    host: str = typer.Option(None, "--host", "-h", help="HTTP host (IPv4) default is 127.0.0.1/localhost (omit for stdio mode)"),
     state_dir: Optional[str] = typer.Option(
         None,
         "--state-dir",
         help="State directory for SymDex indexes and registry (for example .symdex)",
     ),
 ) -> None:
-    """Start the MCP server."""
+    """Start the MCP server.
+    
+    :param host: The host to bind the server to. If omitted, will use mcp defaults.
+    :type host: str, optional
+    :param port: The port to bind the server to. If omitted, will use mcp defaults.
+    :type port: int, optional
+    """ 
+    
+    input_args = locals().keys() - ["state_dir"]
+    # drop state_dir from kwargs since it is handled separately
+    kwargs ={
+        i: locals().get(i) for i in input_args if not isinstance(
+            locals().get(i),type(None)
+        )
+    }
+    # bundle everything into kwargs for future expansion of serve command
+    
+    if not isinstance(port, type(None)):
+        assert isinstance(port, int) and 0 < port < 65536, f"Invalid port: {port}. Must be an integer between 1 and 65535"
+    if host and host != "localhost":
+        assert host.count(".") == 3, f"Invalid host: {host}"
+        assert all([0 <= int(x if x.isdigit() else -1) <256 for x in host.split(".")]), f"Invalid host: {host}. Must be a valid IPv4 address"
+    #quick check to ensure host is a valid IPv4 address IPv6 not added 
+
     _apply_state_dir_override(state_dir)
     _maybe_print_update_notice(sys.argv[1:])
     from symdex.mcp.server import mcp
-    if port:
-        mcp.run(transport="streamable-http", port=port)
+    if len(kwargs) != 0:
+        mcp.run(transport="streamable-http", **kwargs)
     else:
         mcp.run()
 

--- a/tests/unit/test_cli_server_args.py
+++ b/tests/unit/test_cli_server_args.py
@@ -1,0 +1,93 @@
+"""Tests the cli serve function with port and host arguments set with some edge cases tested.
+"""
+import pytest
+from unittest import mock
+from symdex.cli import serve
+
+@pytest.fixture(autouse=True)
+def mock_environment():
+    """Mocks the entire application environment state needed by symdex/cli."""
+    with mock.patch("symdex.cli._maybe_print_update_notice"), mock.patch(
+        "symdex.mcp.server.mcp"
+    ) as mock_mcp:
+        yield mock_mcp
+
+
+def test_serve_happy_path(mock_environment):
+    """Test case: Successful call with no arguments (relying on defaults)."""
+    # Arrange: We expect the function call to proceed without asserting an error,
+    # which means our mock setup is sufficient for a 'pass' state.
+    # We capture the function execution and ensure it doesn't raise an unhandled exception.
+    serve(port=None, host=None, state_dir=None)
+    mock_environment.run.assert_called_once_with()
+
+
+def test_serve_explicit_params_success(mock_environment):
+    """Test case: Successful call with valid explicit port and host."""
+    test_host = "127.0.0.1"
+    test_port = 8080
+    
+    serve(host=test_host, port=test_port, state_dir=None)
+    
+    mock_environment.run.assert_called_once_with(
+        transport="streamable-http", host=test_host, port=test_port
+    )
+
+
+@pytest.mark.parametrize("invalid_host, msg", [
+    ("127.0.0.1.5", "Invalid host"),  
+    ("127.0..1", "Invalid host"),
+    ("127.0.a.1", "Invalid host"),
+    ("Hello world", "Invalid host"),
+    ("....", "Invalid host")
+])
+def test_serve_explicit_params_failure(invalid_host, msg):
+    """Test case: Should fail validation for invalid hosts."""
+    with pytest.raises(AssertionError) as excinfo:
+        serve(host=invalid_host, port=8080, state_dir=None)
+    assert msg in str(excinfo.value)
+
+
+def test_serve_unknown_ip_format():
+    """Test case: Fails on host string that looks like an IP but isn't valid (e.g., text)."""
+    # Test non-IP string format
+    with pytest.raises(AssertionError):
+        serve(host="not-an-ip", port=8080, state_dir=None)
+
+
+@pytest.mark.parametrize("invalid_port", [
+    0,                  # Port too low
+    65537,               # Port too high
+    "hello",               # not a port
+    11.6               # float 
+])
+def test_serve_port_validation(invalid_port):
+    """Test case: Should fail validation if the port is out of range."""
+    # Test using parameterized invalid ports
+    with pytest.raises(AssertionError):
+        serve(port=invalid_port, host="localhost", state_dir=None)
+
+
+def test_serve_valid_edge_case_ports():
+    """Test case: Should succeed for min and max valid ports."""
+    # 1. Min Port Test (Should pass silently)
+    with mock.patch("symdex.mcp.server.mcp") as mock_mcp:
+        serve(port=1, host="localhost", state_dir=None)
+        mock_mcp.run.assert_called_once()
+
+    # 2. Max Port Test (Should pass silently)
+    with mock.patch("symdex.mcp.server.mcp") as mock_mcp:
+        serve(port=65535, host="localhost", state_dir=None)
+        mock_mcp.run.assert_called_once()
+
+
+def test_serve_mixed_and_missing_params(mock_environment):
+    """Test case: Valid combination of missing and present arguments."""
+    # Test 1: Host provided, port missing (Should pass validation if host is valid)
+    serve(host="localhost", port=None, state_dir=None)
+    mock_environment.run.assert_called_once_with(transport="streamable-http", host="localhost")
+    mock_environment.run.reset_mock()
+
+    # Test 2: Port provided, host missing (Should pass validation if port is valid)
+    serve(port=3000, host=None, state_dir=None)
+    mock_environment.run.assert_called_once_with(transport="streamable-http", port=3000)


### PR DESCRIPTION
examples:
```shell
symdex serve --host 0.0.0.0
symdex serve --host localhost
symdex serve --host 127.0.0.1
```

modified the serve function to support adding of more variables that will auto route into the mcp.run command via `kwargs` (no impact to port flag it is now bundled into kwargs).

Added some unit tests to support the addition.
Added some assertions around the host and port flags to set more friendly error messages (can be removed since mcp.run does handle them).


Use case: Needed to expose symdex to 0.0.0.0 so i could connect to it via another client device on the same network.